### PR TITLE
Fixed _size variable names in AGTestCommandResultOutputSize.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,12 @@ export { Comment, CommentData, CommentObserver, NewCommentData } from './src/com
 export { Criterion, CriterionData, CriterionObserver, NewCriterionData } from './src/criterion';
 export { CriterionResult, CriterionResultData, CriterionResultObserver,
          NewCriterionResultData } from './src/criterion_result';
-export { HandgradingResult, HandgradingResultData,
-         HandgradingResultObserver } from './src/handgrading_result';
+export {
+    GroupWithHandgradingResultSummary,
+    HandgradingResult,
+    HandgradingResultData,
+    HandgradingResultObserver,
+    HandgradingResultPage,
+} from './src/handgrading_result';
 export { HandgradingRubric, HandgradingRubricData, HandgradingRubricObserver,
          NewHandgradingRubricData, PointsStyle} from './src/handgrading_rubric';

--- a/src/handgrading_result.ts
+++ b/src/handgrading_result.ts
@@ -189,7 +189,7 @@ export interface GroupWithHandgradingResultSummary {
         finished_grading: boolean;
         total_points: number;
         total_points_possible: number;
-    };
+    } | null;
 }
 
 export class HandgradingResultPage {

--- a/src/handgrading_result.ts
+++ b/src/handgrading_result.ts
@@ -83,18 +83,18 @@ export class HandgradingResult extends HandgradingResultCoreData implements Save
         HandgradingResult._subscribers.delete(observer);
     }
 
-    static async get_all_summary_from_project(project_pk: number,
-                                              page_url: string = '',
-                                              include_staff: boolean = true,
-                                              page_num: number = 1,
-                                              page_size: number = 1000
-    ): Promise<SubmissionGroupHandgradingInfo> {
+    static async get_all_from_project(project_pk: number,
+                                      page_url: string = '',
+                                      include_staff: boolean = true,
+                                      page_num: number = 1,
+                                      page_size: number = 1000
+    ): Promise<HandgradingResultPage> {
         const queries = `?page_size=${page_size}&page=${page_num}&include_staff=${include_staff}`;
         const url = page_url !== '' ? page_url :
             `/projects/${project_pk}/handgrading_results/${queries}`;
 
-        let response = await HttpClient.get_instance().get<SubmissionGroupHandgradingInfo>(url);
-        return new SubmissionGroupHandgradingInfo(response.data);
+        let response = await HttpClient.get_instance().get<HandgradingResultPage>(url);
+        return new HandgradingResultPage(response.data);
     }
 
     static async get_by_group_pk(group_pk: number): Promise<HandgradingResult> {
@@ -167,7 +167,7 @@ export class HandgradingResult extends HandgradingResultCoreData implements Save
     ];
 }
 
-export interface GroupHandgradingResultSummary {
+export interface GroupWithHandgradingResultSummary {
     pk: number;
     project: number;
     extended_due_date: string;
@@ -184,13 +184,13 @@ export interface GroupHandgradingResultSummary {
     };
 }
 
-export class SubmissionGroupHandgradingInfo {
+export class HandgradingResultPage {
     count: number;
     next: string;
     previous: string;
-    results: GroupHandgradingResultSummary[];
+    results: GroupWithHandgradingResultSummary[];
 
-    constructor(args: SubmissionGroupHandgradingInfo) {
+    constructor(args: HandgradingResultPage) {
         this.count = args.count;
         this.next = args.next;
         this.previous = args.previous;

--- a/src/handgrading_result.ts
+++ b/src/handgrading_result.ts
@@ -83,11 +83,19 @@ export class HandgradingResult extends HandgradingResultCoreData implements Save
         HandgradingResult._subscribers.delete(observer);
     }
 
-    static async get_all_from_project(project_pk: number,
-                                      page_url: string = '',
-                                      include_staff: boolean = true,
-                                      page_num: number = 1,
-                                      page_size: number = 1000
+    static async get_all_summaries_from_project(
+        project_pk: number,
+        {
+            page_url = '',
+            include_staff = true,
+            page_num = 1,
+            page_size = 1000,
+        }: {
+            page_url?: string,
+            include_staff?: boolean,
+            page_num?: number,
+            page_size?: number,
+        } = {}
     ): Promise<HandgradingResultPage> {
         const queries = `?page_size=${page_size}&page=${page_num}&include_staff=${include_staff}`;
         const url = page_url !== '' ? page_url :

--- a/src/submission_result.ts
+++ b/src/submission_result.ts
@@ -38,10 +38,10 @@ export namespace ResultOutput {
     }
 
     export interface AGTestCommandResultOutputSize {
-        stdout: number | null;
-        stderr: number | null;
-        stdout_diff: number | null;
-        stderr_diff: number | null;
+        stdout_size: number | null;
+        stderr_size: number | null;
+        stdout_diff_size: number | null;
+        stderr_diff_size: number | null;
     }
 
     export async function get_ag_test_cmd_result_stdout(

--- a/tests/test_handgrading_result.ts
+++ b/tests/test_handgrading_result.ts
@@ -279,7 +279,7 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         await group.refresh();
         await group2.refresh();
         let loaded_handgrading_results_info =
-            await HandgradingResult.get_all_summary_from_project(project.pk);
+            await HandgradingResult.get_all_from_project(project.pk);
 
         expect(loaded_handgrading_results_info.count).toEqual(2);
         expect(loaded_handgrading_results_info.next).toBeNull();
@@ -352,7 +352,7 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
 
         run_in_django_shell(create_handgrading_results);
         let loaded_second_handgrading_results_page =
-            await HandgradingResult.get_all_summary_from_project(project.pk, '', true, 2, 1);
+            await HandgradingResult.get_all_from_project(project.pk, '', true, 2, 1);
 
         expect(loaded_second_handgrading_results_page.count).toEqual(3);
 
@@ -394,7 +394,7 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         run_in_django_shell(create_handgrading_results);
         await sleep(2);
         let loaded_handgrading_results_info =
-            await HandgradingResult.get_all_summary_from_project(project.pk, '', false);
+            await HandgradingResult.get_all_from_project(project.pk, '', false);
 
         expect(loaded_handgrading_results_info.count).toEqual(1);
         expect(loaded_handgrading_results_info.next).toBeNull();
@@ -438,10 +438,10 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
 
         run_in_django_shell(create_handgrading_results);
         let loaded_second_handgrading_results_page =
-            await HandgradingResult.get_all_summary_from_project(project.pk, '', true, 2, 1);
+            await HandgradingResult.get_all_from_project(project.pk, '', true, 2, 1);
         let next_url = loaded_second_handgrading_results_page.next;
         let loaded_third_handgrading_results_page =
-            await HandgradingResult.get_all_summary_from_project(project.pk, next_url);
+            await HandgradingResult.get_all_from_project(project.pk, next_url);
 
         expect(loaded_third_handgrading_results_page.count).toEqual(3);
 
@@ -460,7 +460,7 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
         let created = await HandgradingResult.get_or_create(group.pk);
 
         // First check if result from summary matches
-        let loaded_summary = await HandgradingResult.get_all_summary_from_project(project.pk);
+        let loaded_summary = await HandgradingResult.get_all_from_project(project.pk);
         expect(loaded_summary.count).toEqual(2);
         let sorted_results = loaded_summary.results.sort((a, b) => b.pk - a.pk);
         // Highest pk will be one that was just created

--- a/tests/test_handgrading_result.ts
+++ b/tests/test_handgrading_result.ts
@@ -279,7 +279,7 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         await group.refresh();
         await group2.refresh();
         let loaded_handgrading_results_info =
-            await HandgradingResult.get_all_from_project(project.pk);
+            await HandgradingResult.get_all_summaries_from_project(project.pk);
 
         expect(loaded_handgrading_results_info.count).toEqual(2);
         expect(loaded_handgrading_results_info.next).toBeNull();
@@ -352,7 +352,8 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
 
         run_in_django_shell(create_handgrading_results);
         let loaded_second_handgrading_results_page =
-            await HandgradingResult.get_all_from_project(project.pk, '', true, 2, 1);
+            await HandgradingResult.get_all_summaries_from_project(
+                project.pk, {page_num: 2, page_size: 1});
 
         expect(loaded_second_handgrading_results_page.count).toEqual(3);
 
@@ -394,7 +395,8 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         run_in_django_shell(create_handgrading_results);
         await sleep(2);
         let loaded_handgrading_results_info =
-            await HandgradingResult.get_all_from_project(project.pk, '', false);
+            await HandgradingResult.get_all_summaries_from_project(
+                project.pk, {include_staff: false});
 
         expect(loaded_handgrading_results_info.count).toEqual(1);
         expect(loaded_handgrading_results_info.next).toBeNull();
@@ -438,10 +440,12 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
 
         run_in_django_shell(create_handgrading_results);
         let loaded_second_handgrading_results_page =
-            await HandgradingResult.get_all_from_project(project.pk, '', true, 2, 1);
+            await HandgradingResult.get_all_summaries_from_project(
+                project.pk, {page_num: 2, page_size: 1});
         let next_url = loaded_second_handgrading_results_page.next;
         let loaded_third_handgrading_results_page =
-            await HandgradingResult.get_all_from_project(project.pk, next_url);
+            await HandgradingResult.get_all_summaries_from_project(
+                project.pk, {page_url: next_url});
 
         expect(loaded_third_handgrading_results_page.count).toEqual(3);
 
@@ -460,7 +464,7 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
         let created = await HandgradingResult.get_or_create(group.pk);
 
         // First check if result from summary matches
-        let loaded_summary = await HandgradingResult.get_all_from_project(project.pk);
+        let loaded_summary = await HandgradingResult.get_all_summaries_from_project(project.pk);
         expect(loaded_summary.count).toEqual(2);
         let sorted_results = loaded_summary.results.sort((a, b) => b.pk - a.pk);
         // Highest pk will be one that was just created

--- a/tests/test_handgrading_result.ts
+++ b/tests/test_handgrading_result.ts
@@ -299,9 +299,9 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         expect(sorted_results[0].num_submissions).toEqual(group.num_submissions);
         expect(sorted_results[0].num_submits_towards_limit).toEqual(
             group.num_submits_towards_limit);
-        expect(sorted_results[0].handgrading_result.finished_grading).toEqual(false);
-        expect(sorted_results[0].handgrading_result.total_points).toEqual(2);
-        expect(sorted_results[0].handgrading_result.total_points_possible).toEqual(0);
+        expect(sorted_results[0].handgrading_result!.finished_grading).toEqual(false);
+        expect(sorted_results[0].handgrading_result!.total_points).toEqual(2);
+        expect(sorted_results[0].handgrading_result!.total_points_possible).toEqual(0);
 
         // Check second result info
         expect(sorted_results[1].pk).toEqual(2);
@@ -314,9 +314,9 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         expect(sorted_results[1].num_submissions).toEqual(group2.num_submissions);
         expect(sorted_results[1].num_submits_towards_limit).toEqual(
             group2.num_submits_towards_limit);
-        expect(sorted_results[1].handgrading_result.finished_grading).toEqual(false);
-        expect(sorted_results[1].handgrading_result.total_points).toEqual(5);
-        expect(sorted_results[1].handgrading_result.total_points_possible).toEqual(0);
+        expect(sorted_results[1].handgrading_result!.finished_grading).toEqual(false);
+        expect(sorted_results[1].handgrading_result!.total_points).toEqual(5);
+        expect(sorted_results[1].handgrading_result!.total_points_possible).toEqual(0);
     });
 
 
@@ -403,7 +403,7 @@ HandgradingResult.objects.validate_and_create(group=group2, handgrading_rubric=h
         expect(loaded_handgrading_results_info.previous).toBeNull();
 
         let actual_total_points = loaded_handgrading_results_info.results.map(
-            result => result.handgrading_result.total_points);
+            result => result.handgrading_result!.total_points);
         expect(actual_total_points).toEqual([5]);
     });
 
@@ -472,14 +472,12 @@ HandgradingResult.objects.validate_and_create(group=group3, handgrading_rubric=h
 
         expect(created.pk).toEqual(actual_result_summary.pk);
 
-        expect(actual_result_summary.handgrading_result.finished_grading).toEqual(false);
-        expect(actual_result_summary.handgrading_result.total_points).toEqual(0);
-        expect(actual_result_summary.handgrading_result.total_points_possible).toEqual(0);
+        expect(actual_result_summary.handgrading_result!.finished_grading).toEqual(false);
+        expect(actual_result_summary.handgrading_result!.total_points).toEqual(0);
+        expect(actual_result_summary.handgrading_result!.total_points_possible).toEqual(0);
 
-        // If statement included to suppress tslint "object could be null" error
-        if (observer.handgrading_result !== null) {
-            expect(observer.handgrading_result.pk).toEqual(actual_result_summary.pk);
-        }
+        expect(observer.handgrading_result!.pk).toEqual(actual_result_summary.pk);
+
         expect(observer.created_count).toEqual(1);
         expect(observer.changed_count).toEqual(0);
         expect(observer.deleted_count).toEqual(0);


### PR DESCRIPTION
Renamed and exported some handgrading result types.
Made GroupWithHandgradingResultSummary.handgrading_result nullable.