### PR TITLE
Implemented faster method of clearing database between tests.

### DIFF
--- a/tests/test_ag_test_suite.ts
+++ b/tests/test_ag_test_suite.ts
@@ -38,9 +38,6 @@ test('Get sandbox docker images', async () => {
     let make_images = `
 from autograder.core.models import SandboxDockerImage
 
-# Get rid of the default image
-SandboxDockerImage.objects.all().delete()
-
 SandboxDockerImage.objects.validate_and_create(
     name='image1',
     tag='image1:1',
@@ -79,7 +76,7 @@ SandboxDockerImage.objects.validate_and_create(
         }
     ];
 
-    let images = await get_sandbox_docker_images();
+    let images = (await get_sandbox_docker_images()).filter(image => image.name !== 'default');
     let actual = images.map((image) => filter_keys(image, ['name', 'tag', 'display_name']));
     expect(actual).toEqual(expected);
 });

--- a/tests/test_annotation.ts
+++ b/tests/test_annotation.ts
@@ -118,7 +118,7 @@ Annotation.objects.validate_and_create(handgrading_rubric=handgrading_rubric, de
     test('Create annotation only required fields', async () => {
         let created = await Annotation.create(handgrading_rubric.pk, {});
 
-        let loaded = await Annotation.get_all_from_handgrading_rubric(project.pk);
+        let loaded = await Annotation.get_all_from_handgrading_rubric(handgrading_rubric.pk);
         expect(loaded.length).toEqual(1);
         let actual = loaded[0];
 
@@ -147,7 +147,7 @@ Annotation.objects.validate_and_create(handgrading_rubric=handgrading_rubric, de
             })
         );
 
-        let loaded = await Annotation.get_all_from_handgrading_rubric(project.pk);
+        let loaded = await Annotation.get_all_from_handgrading_rubric(handgrading_rubric.pk);
         expect(loaded.length).toEqual(1);
         let actual = loaded[0];
 
@@ -184,7 +184,7 @@ describe('Get/update/delete annotation tests', () => {
     let annotation!: Annotation;
 
     beforeEach(async () => {
-        annotation = await Annotation.create(project.pk, {});
+        annotation = await Annotation.create(handgrading_rubric.pk, {});
     });
 
     test('Get annotation', async () => {

--- a/tests/test_applied_annotation.ts
+++ b/tests/test_applied_annotation.ts
@@ -215,7 +215,8 @@ describe('Get/delete applied annotation tests', () => {
         expect(observer.created_count).toEqual(1);
         expect(observer.deleted_count).toEqual(1);
 
-        let loaded_list = await AppliedAnnotation.get_all_from_handgrading_result(project.pk);
+        let loaded_list = await AppliedAnnotation.get_all_from_handgrading_result(
+            handgrading_result.pk);
         expect(loaded_list.length).toEqual(0);
     });
 });

--- a/tests/test_comment.ts
+++ b/tests/test_comment.ts
@@ -119,7 +119,8 @@ Comment.objects.validate_and_create(handgrading_result=result, text='comment 3')
     });
 
     test('Create comment only required fields', async () => {
-        let created = await Comment.create(project.pk, new NewCommentData({text: 'comment text'}));
+        let created = await Comment.create(
+            handgrading_result.pk, new NewCommentData({text: 'comment text'}));
 
         let loaded = await Comment.get_all_from_handgrading_result(handgrading_result.pk);
         expect(loaded.length).toEqual(1);
@@ -138,7 +139,7 @@ Comment.objects.validate_and_create(handgrading_result=result, text='comment 3')
 
     test('Create comment all fields', async () => {
         let created = await Comment.create(
-            project.pk,
+            handgrading_result.pk,
             new NewCommentData({
                 text: 'some other text',
                 location: {
@@ -191,7 +192,7 @@ describe('Get/update/delete comment tests', () => {
     let comment!: Comment;
 
     beforeEach(async () => {
-        comment = await Comment.create(project.pk, {text: 'text here'});
+        comment = await Comment.create(handgrading_result.pk, {text: 'text here'});
     });
 
     test('Get comment file', async () => {

--- a/tests/test_course.ts
+++ b/tests/test_course.ts
@@ -7,7 +7,9 @@ import {
     reset_db,
     run_in_django_shell,
     sleep,
-    SUPERUSER_NAME
+    SUPERUSER_NAME,
+    timeit,
+    timeit_async
 } from './utils';
 
 beforeAll(() => {

--- a/tests/test_criterion.ts
+++ b/tests/test_criterion.ts
@@ -116,7 +116,7 @@ Criterion.objects.validate_and_create(handgrading_rubric=handgrading_rubric, poi
     test('Create criterion only required fields', async () => {
         let created = await Criterion.create(handgrading_rubric.pk, {});
 
-        let loaded = await Criterion.get_all_from_handgrading_rubric(project.pk);
+        let loaded = await Criterion.get_all_from_handgrading_rubric(handgrading_rubric.pk);
         expect(loaded.length).toEqual(1);
         let actual = loaded[0];
 
@@ -143,7 +143,7 @@ Criterion.objects.validate_and_create(handgrading_rubric=handgrading_rubric, poi
             })
         );
 
-        let loaded = await Criterion.get_all_from_handgrading_rubric(project.pk);
+        let loaded = await Criterion.get_all_from_handgrading_rubric(handgrading_rubric.pk);
         expect(loaded.length).toEqual(1);
         let actual = loaded[0];
 
@@ -179,7 +179,7 @@ describe('Get/update/delete criterion tests', () => {
     let criterion!: Criterion;
 
     beforeEach(async () => {
-        criterion = await Criterion.create(project.pk, {});
+        criterion = await Criterion.create(handgrading_rubric.pk, {});
     });
 
     test('Get criterion', async () => {

--- a/tests/test_criterion_result.ts
+++ b/tests/test_criterion_result.ts
@@ -74,7 +74,7 @@ submission.save()
     run_in_django_shell(create_submission);
 
     handgrading_result = await HandgradingResult.get_or_create(group.pk);
-    criterion = await Criterion.create(handgrading_rubric.pk, {});
+    criterion = await Criterion.create(handgrading_rubric.pk, {short_description: 'Criterion1'});
 
     // A CriterionResult is automatically created for each HandgradingResult when a Criterion is
     // created. We want to get the pk of this CriterionResult for later use
@@ -120,8 +120,10 @@ from autograder.handgrading.models import (
 rubric = HandgradingRubric.objects.get(pk=${handgrading_rubric.pk})
 result = HandgradingResult.objects.get(pk=${handgrading_result.pk})
 
-c2 = Criterion.objects.validate_and_create(handgrading_rubric=rubric)
-c3 = Criterion.objects.validate_and_create(handgrading_rubric=rubric)
+c2 = Criterion.objects.validate_and_create(
+    handgrading_rubric=rubric, short_description='Criterion2')
+c3 = Criterion.objects.validate_and_create(
+    handgrading_rubric=rubric, short_description='Criterion3')
 
 CriterionResult.objects.validate_and_create(handgrading_result=result, selected=True, criterion=c2)
 CriterionResult.objects.validate_and_create(handgrading_result=result, selected=True, criterion=c3)
@@ -133,18 +135,19 @@ CriterionResult.objects.validate_and_create(handgrading_result=result, selected=
 
         let sorted_criterion_results = loaded_criterion_results.sort((a, b) => a.pk - b.pk);
         expect(sorted_criterion_results.length).toEqual(3);
-        expect(sorted_criterion_results[0].pk).toEqual(1);
+        expect(sorted_criterion_results[0].pk).toEqual(criterion_result_pk);
         expect(sorted_criterion_results[0].selected).toEqual(false);
         expect(sorted_criterion_results[0].handgrading_result).toEqual(handgrading_result.pk);
         expect(sorted_criterion_results[0].criterion).toEqual(criterion);
 
-        expect(sorted_criterion_results[1].pk).toEqual(2);
         expect(sorted_criterion_results[1].selected).toEqual(true);
         expect(sorted_criterion_results[1].handgrading_result).toEqual(handgrading_result.pk);
+        expect(sorted_criterion_results[1].criterion.short_description).toEqual('Criterion2');
 
-        expect(sorted_criterion_results[2].pk).toEqual(3);
+        // expect(sorted_criterion_results[2].pk).toEqual(3);
         expect(sorted_criterion_results[2].selected).toEqual(true);
         expect(sorted_criterion_results[2].handgrading_result).toEqual(handgrading_result.pk);
+        expect(sorted_criterion_results[2].criterion.short_description).toEqual('Criterion3');
     });
 });
 

--- a/tests/test_handgrading_rubric.ts
+++ b/tests/test_handgrading_rubric.ts
@@ -142,14 +142,16 @@ from autograder.core.models import Project
 from autograder.handgrading.models import HandgradingRubric
 project = Project.objects.get(pk=${project.pk})
 
-HandgradingRubric.objects.validate_and_create(project=project, max_points=321)
+rubric = HandgradingRubric.objects.validate_and_create(project=project, max_points=321)
+print(rubric.pk)
         `;
 
-        run_in_django_shell(create_handgrading_rubric);
+        let result = run_in_django_shell(create_handgrading_rubric);
+        let expected_pk = parseInt(result.stdout, 10);
         let loaded_handgrading_rubric = await HandgradingRubric.get_from_project(project.pk);
 
         // Make sure the loaded HandgradingRubric is the correct one
-        expect(loaded_handgrading_rubric.pk).toEqual(1);
+        expect(loaded_handgrading_rubric.pk).toEqual(expected_pk);
         expect(loaded_handgrading_rubric.project).toEqual(project.pk);
         expect(loaded_handgrading_rubric.points_style).toEqual(PointsStyle.start_at_zero_and_add);
         expect(loaded_handgrading_rubric.max_points).toEqual(321);

--- a/tests/test_submission_result.ts
+++ b/tests/test_submission_result.ts
@@ -12,6 +12,7 @@ let ag_test_cmd: cli.AGTestCommand;
 let mutation_test_suite: cli.MutationTestSuite;
 
 let ag_test_suite_result_pk: ID;
+let ag_test_case_result_pk: ID;
 let ag_test_cmd_result_pk: ID;
 let mutation_test_suite_result_pk: ID;
 
@@ -178,11 +179,12 @@ with open(cmd_result.stdout_filename, 'w') as f:
 with open(cmd_result.stderr_filename, 'w') as f:
     f.write('${ag_test_cmd_actual_stderr}')
 
-print(cmd_result.pk)
+print(f'{case_result.pk} {cmd_result.pk}')
     `;
 
     result = run_in_django_shell(make_ag_test_cmd_result);
-    ag_test_cmd_result_pk = parseInt(result.stdout, 10);
+    [ag_test_case_result_pk, ag_test_cmd_result_pk]
+        = result.stdout.split(' ').map(id => parseInt(id, 10));
 
     let make_mutation_test_suite_result = `
 from autograder.core.models import StudentTestSuiteResult, AGCommandResult
@@ -262,7 +264,7 @@ describe('get_submission_result tests', () => {
                     ag_test_case_name: ag_test_case.name,
                     ag_test_case_pk: ag_test_case.pk,
                     fdbk_settings: ag_test_case.staff_viewer_fdbk_config, // should be same as max
-                    pk: ag_test_case.pk,
+                    pk: ag_test_case_result_pk,
 
                     total_points: 1,
                     total_points_possible: 7,
@@ -337,7 +339,7 @@ describe('get_submission_result tests', () => {
                     ag_test_case_name: ag_test_case.name,
                     ag_test_case_pk: ag_test_case.pk,
                     fdbk_settings: ag_test_case.normal_fdbk_config, // should be same as max
-                    pk: ag_test_case.pk,
+                    pk: ag_test_case_result_pk,
 
                     total_points: 0,
                     total_points_possible: 0,

--- a/tests/test_user.ts
+++ b/tests/test_user.ts
@@ -302,8 +302,8 @@ Group.objects.validate_and_create(members=[user], project=p2)
         expect(groups[0].pk).not.toEqual(groups[1].pk);
 
         groups.sort((a: Group, b: Group) => a.pk - b.pk);
-        expect((await Project.get_by_pk(groups[0].pk)).name).toEqual('P1');
-        expect((await Project.get_by_pk(groups[1].pk)).name).toEqual('P2');
+        expect((await Project.get_by_pk(groups[0].project)).name).toEqual('P1');
+        expect((await Project.get_by_pk(groups[1].project)).name).toEqual('P2');
     });
 });
 


### PR DESCRIPTION
We observed that (on my ubuntu 18 desktop):
- Subprocess calls add about 1s of overhead
- A subprocess call to manage.py flush takes about 4s
To optimize reset_db, we:
- Consolidated subprocess calls for clearing the database, deleting files,
  and clearing the cache into one call.
- Deleted all Courses, Users, and SandboxDockerImages (besides the default one)
  instead of calling manage.py flush. Since these are our top-level datatypes,
  we let the cascade deletion take care of everything else.

After making this change, fixed test cases that had pk mismatch bugs.