### PR TITLE
Move submission results functions into a namespace

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -66,11 +66,11 @@ export {
 
 export {
     FeedbackCategory,
-    get_all_minimal_ultimate_submission_results,
-    get_all_ultimate_submission_results,
-    UltimateSubmissionResult,
-    UltimateSubmissionResultPage,
-    get_submission_result,
+    SubmissionResults,
+    FullUltimateSubmissionResult,
+    MinimalUltimateSubmissionResult,
+    FullUltimateSubmissionResultPage,
+    MinimalUltimateSubmissionResultPage,
     ResultOutput,
     SubmissionResultFeedback,
     AGTestSuiteResultFeedback,

--- a/src/submission_result.ts
+++ b/src/submission_result.ts
@@ -14,71 +14,79 @@ export enum FeedbackCategory {
     max = 'max',
 }
 
-export async function get_all_ultimate_submission_results(
-    project_pk: number,
-    {
-        include_staff = true,
-        page_num = 1,
-        page_size = 100,
-    }: {
-        include_staff?: boolean,
-        page_num?: number,
-        page_size?: number,
-    } = {}
-): Promise<UltimateSubmissionResultPage<false>> {
-    type ResponseType = UltimateSubmissionResultPage<false>;
-    let response = await HttpClient.get_instance().get<ResponseType>(
-        `projects/${project_pk}/all_ultimate_submission_results/`
-        + `?page=${page_num}&groups_per_page=${page_size}`
-        + `&full_results=true&include_staff=${include_staff}`
-    );
-    return response.data;
+// tslint:disable-next-line: no-namespace
+export namespace SubmissionResults {
+    export async function get_all_ultimate_submission_results(
+        project_pk: number,
+        {
+            include_staff = true,
+            page_num = 1,
+            page_size = 100,
+        }: {
+            include_staff?: boolean,
+            page_num?: number,
+            page_size?: number,
+        } = {}
+    ): Promise<UltimateSubmissionResultPage<false>> {
+        type ResponseType = UltimateSubmissionResultPage<false>;
+        let response = await HttpClient.get_instance().get<ResponseType>(
+            `projects/${project_pk}/all_ultimate_submission_results/`
+            + `?page=${page_num}&groups_per_page=${page_size}`
+            + `&full_results=true&include_staff=${include_staff}`
+        );
+        return response.data;
+    }
+
+    export async function get_all_minimal_ultimate_submission_results(
+        project_pk: number,
+        {
+            include_staff = true,
+            page_num = 1,
+            page_size = 100,
+        }: {
+            include_staff?: boolean,
+            page_num?: number,
+            page_size?: number,
+        } = {}
+    ): Promise<UltimateSubmissionResultPage<true>> {
+        type ResponseType = UltimateSubmissionResultPage<true>;
+        let response = await HttpClient.get_instance().get<ResponseType>(
+            `projects/${project_pk}/all_ultimate_submission_results/`
+            + `?page=${page_num}&groups_per_page=${page_size}`
+            + `&full_results=false&include_staff=${include_staff}`
+        );
+        return response.data;
+    }
+
+    export async function get_submission_result(
+        submission_pk: ID,
+        feedback_category: FeedbackCategory
+    ): Promise<SubmissionResultFeedback> {
+        let response = await HttpClient.get_instance().get<SubmissionResultFeedback>(
+            `/submissions/${submission_pk}/results/?feedback_category=${feedback_category}`);
+        return response.data;
+    }
 }
 
-export async function get_all_minimal_ultimate_submission_results(
-    project_pk: number,
-    {
-        include_staff = true,
-        page_num = 1,
-        page_size = 100,
-    }: {
-        include_staff?: boolean,
-        page_num?: number,
-        page_size?: number,
-    } = {}
-): Promise<UltimateSubmissionResultPage<true>> {
-    type ResponseType = UltimateSubmissionResultPage<true>;
-    let response = await HttpClient.get_instance().get<ResponseType>(
-        `projects/${project_pk}/all_ultimate_submission_results/`
-        + `?page=${page_num}&groups_per_page=${page_size}`
-        + `&full_results=false&include_staff=${include_staff}`
-    );
-    return response.data;
-}
+export type FullUltimateSubmissionResultPage = UltimateSubmissionResultPage<false>;
+export type MinimalUltimateSubmissionResultPage = UltimateSubmissionResultPage<true>;
+export type FullUltimateSubmissionResult = UltimateSubmissionResult<false>;
+export type MinimalUltimateSubmissionResult = UltimateSubmissionResult<true>;
 
-export interface UltimateSubmissionResultPage<Minimal extends boolean> {
+interface UltimateSubmissionResultPage<Minimal extends boolean> {
     count: number;
     next: string | null;
     previous: string | null;
     results: UltimateSubmissionResult<Minimal>[];
 }
 
-export interface UltimateSubmissionResult<Minimal extends boolean> {
+interface UltimateSubmissionResult<Minimal extends boolean> {
     username: string;
     group: Group;
     ultimate_submission: {
         results: Minimal extends true
             ? MinimalSubmissionResultFeedback : SubmissionResultFeedback
     };
-}
-
-export async function get_submission_result(
-    submission_pk: ID,
-    feedback_category: FeedbackCategory
-): Promise<SubmissionResultFeedback> {
-    let response = await HttpClient.get_instance().get<SubmissionResultFeedback>(
-        `/submissions/${submission_pk}/results/?feedback_category=${feedback_category}`);
-    return response.data;
 }
 
 // tslint:disable-next-line: no-namespace

--- a/tests/test_submission_result.ts
+++ b/tests/test_submission_result.ts
@@ -1,23 +1,20 @@
 import * as cli from '..';
-import { ID } from '../src/base';
-import { Group } from '../src/group';
-import { AGTestSuiteResultFeedback, MutationTestSuiteResultFeedback } from '../src/submission_result';
 
 import { global_setup, make_superuser, reset_db, run_in_django_shell } from "./utils";
 
 let course: cli.Course;
 let project: cli.Project;
-let group: Group;
-let submission_pk: ID;
+let group: cli.Group;
+let submission_pk: cli.ID;
 let ag_test_suite: cli.AGTestSuite;
 let ag_test_case: cli.AGTestCase;
 let ag_test_cmd: cli.AGTestCommand;
 let mutation_test_suite: cli.MutationTestSuite;
 
-let ag_test_suite_result_pk: ID;
-let ag_test_case_result_pk: ID;
-let ag_test_cmd_result_pk: ID;
-let mutation_test_suite_result_pk: ID;
+let ag_test_suite_result_pk: cli.ID;
+let ag_test_case_result_pk: cli.ID;
+let ag_test_cmd_result_pk: cli.ID;
+let mutation_test_suite_result_pk: cli.ID;
 
 // Note: Make sure all of these have unique lengths
 let ag_test_suite_setup_stdout = 'a'.repeat(5);
@@ -252,7 +249,8 @@ update_denormalized_ag_test_results(${submission_pk})
 
 describe('Get all ultimate submission results tests', () => {
     test('get_all_minimal_ultimate_submission_results', async () => {
-        let page = await cli.get_all_minimal_ultimate_submission_results(project.pk);
+        let page
+            = await cli.SubmissionResults.get_all_minimal_ultimate_submission_results(project.pk);
         expect(page.results.length).toEqual(1);
         let result = page.results[0];
         expect(result.username).toEqual(group.member_names[0]);
@@ -267,15 +265,15 @@ describe('Get all ultimate submission results tests', () => {
         expect(result.ultimate_submission.results.mutation_test_suite_results).toBeUndefined();
 
         // @ts-expect-error
-        let array: AGTestSuiteResultFeedback[]
+        let array: cli.AGTestSuiteResultFeedback[]
             = result.ultimate_submission.results.ag_test_suite_results;
         // @ts-expect-error
-        let array2: MutationTestSuiteResultFeedback[]
+        let array2: cli.MutationTestSuiteResultFeedback[]
             = result.ultimate_submission.results.mutation_test_suite_results;
     });
 
     test('get_all_ultimate_submission_results', async () => {
-        let page = await cli.get_all_ultimate_submission_results(project.pk);
+        let page = await cli.SubmissionResults.get_all_ultimate_submission_results(project.pk);
         expect(page.results.length).toEqual(1);
         let result = page.results[0];
         expect(result.username).toEqual(group.member_names[0]);
@@ -290,34 +288,34 @@ describe('Get all ultimate submission results tests', () => {
         expect(result.ultimate_submission.results.mutation_test_suite_results).not.toBeUndefined();
 
         // Make sure type of arrays is correct
-        let array: AGTestSuiteResultFeedback[]
+        let array: cli.AGTestSuiteResultFeedback[]
             = result.ultimate_submission.results.ag_test_suite_results;
-        let array2: MutationTestSuiteResultFeedback[]
+        let array2: cli.MutationTestSuiteResultFeedback[]
             = result.ultimate_submission.results.mutation_test_suite_results;
     });
 
     test('get_all_ultimate_submission_results include_staff false', async () => {
-        let page = await cli.get_all_ultimate_submission_results(
+        let page = await cli.SubmissionResults.get_all_ultimate_submission_results(
             project.pk, {include_staff: false});
         expect(page.results.length).toEqual(0);
     });
 
     test('get_all_minimal_ultimate_submission_results include_staff false', async () => {
-        let page = await cli.get_all_minimal_ultimate_submission_results(
+        let page = await cli.SubmissionResults.get_all_minimal_ultimate_submission_results(
             project.pk, {include_staff: false});
         expect(page.results.length).toEqual(0);
     });
 
     // This test is mostly to satisfy branch coverage
     test('get_all_ultimate_submission_results page_size and page_num', async () => {
-        let page = await cli.get_all_ultimate_submission_results(
+        let page = await cli.SubmissionResults.get_all_ultimate_submission_results(
             project.pk, {page_num: 1, page_size: 1});
         expect(page.results.length).toEqual(1);
     });
 
     // This test is mostly to satisfy branch coverage
     test('get_all_minimal_ultimate_submission_results page_size and page_num', async () => {
-        let page = await cli.get_all_minimal_ultimate_submission_results(
+        let page = await cli.SubmissionResults.get_all_minimal_ultimate_submission_results(
             project.pk, {page_num: 1, page_size: 1});
         expect(page.results.length).toEqual(1);
     });
@@ -325,7 +323,9 @@ describe('Get all ultimate submission results tests', () => {
 
 describe('get_submission_result tests', () => {
     test('get_submission_result max feedback', async () => {
-        let result = await cli.get_submission_result(submission_pk, cli.FeedbackCategory.max);
+        let result = await cli.SubmissionResults.get_submission_result(
+            submission_pk, cli.FeedbackCategory.max
+        );
         let expected: cli.SubmissionResultFeedback = {
             pk: submission_pk,
             total_points: '3.00',
@@ -405,7 +405,9 @@ describe('get_submission_result tests', () => {
     });
 
     test('get_submission_result min feedback', async () => {
-        let result = await cli.get_submission_result(submission_pk, cli.FeedbackCategory.normal);
+        let result = await cli.SubmissionResults.get_submission_result(
+            submission_pk, cli.FeedbackCategory.normal
+        );
         let expected: cli.SubmissionResultFeedback = {
             pk: submission_pk,
             total_points: '0.00',


### PR DESCRIPTION
This should let us properly mock these functions in tests.