### PR TITLE
Add build:clean npm script for idempotent builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.8.0",
   "description": "A client for interacting with the autograder.io API.",
   "scripts": {
+    "clean": "rm -rf ./dist",
     "test": "tsc -p . --noEmit && jest --runInBand",
     "lint": "tsc -p . --noEmit && tslint --project .",
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "build:clean": "npm run clean && npm ci && npm run build"
   },
   "author": "James Perretta",
   "license": "LGPL-3.0-only",


### PR DESCRIPTION
Simpler replacement of #166 without all the compilation changes.

Just adds `build:clean` npm script which does an idempotent build. This simplifies re-building, and is useful as a preinstall hook in ag-website-vue.